### PR TITLE
Enhancement 11

### DIFF
--- a/fetch/src/fetch/fetch.h
+++ b/fetch/src/fetch/fetch.h
@@ -15,104 +15,145 @@
 namespace fetch {
     // Typedef
 
+    namespace header {
+        // Typdef
+
+        struct value {
+            // Constructors
+
+            value();
+
+            value(const int value);
+
+            value(const std::string value);
+
+            // Operators
+
+            operator    int();
+
+            operator    std::string();
+
+            int         operator=(const int value);
+
+            std::string operator=(const std::string value);
+
+            bool        operator==(const int value);
+
+            bool        operator==(const std::string value);
+
+            bool        operator==(const struct value value);
+
+            bool        operator!=(const int value);
+
+            bool        operator!=(const std::string value);
+
+            bool        operator!=(const struct value value);
+
+            // Member Functions
+
+            std::string get() const;
+
+            void        get(int& value);
+        private:
+            // Member Fields
+
+            int         _int;
+            bool        _parsed = false;
+            std::string _str;
+
+            // Member Functions
+
+            int         _set(const int value);
+
+            std::string _set(const std::string value);
+        };
+
+        using map = std::map<std::string, header::value>;
+    };
+
     struct response_t {
         // Member Functions
 
         /**
          * Return response header
          */
-        virtual std::string                        get(const std::string key) = 0;
+        virtual header::value get(const std::string key) = 0;
 
-        virtual std::map<std::string, std::string> headers() = 0;
+        virtual header::map   headers() = 0;
 
-        virtual size_t                             status() const = 0;
+        virtual size_t        status() const = 0;
 
-        virtual std::string                        status_text() const = 0;
+        virtual std::string   status_text() const = 0;
 
-        virtual std::string                        text() const = 0;
+        virtual std::string   text() const = 0;
     };
 
     struct error: public std::exception, public response_t {
         // Constructors
 
-        error(
-            const size_t                       status,
-            const std::string                  status_text,
-            const std::string                  text = "",
-            std::map<std::string, std::string> headers = {}
-        );
+        error(const size_t status, const std::string status_text, const std::string text = "", header::map headers = {});
 
         // Member Functions
 
         /**
          * Return response header
          */
-        std::string                        get(const std::string key);
+        header::value get(const std::string key);
 
-        std::map<std::string, std::string> headers();
+        header::map   headers();
 
-        size_t                             status() const;
+        size_t        status() const;
 
-        std::string                        status_text() const;
+        std::string   status_text() const;
 
-        std::string                        text() const;
+        std::string   text() const;
 
-        const char*                        what() const throw();
+        const char*   what() const throw();
     private:
         // Member Fields
 
-        std::map<std::string, std::string> _headers;
-        size_t                             _status;
-        std::string                        _status_text;
-        std::string                        _text;
+        header::map _headers;
+        size_t      _status;
+        std::string _status_text;
+        std::string _text;
     };
 
     struct response: public response_t {
         // Constructors
 
-        response(
-            const size_t                       status,
-            const std::string                  status_text,
-            std::map<std::string, std::string> headers,
-            const std::string                  text
-        );
+        response(const size_t status, const std::string status_text, header::map headers, const std::string text);
 
         // Member Functions
 
         /**
          * Return response header
          */
-        std::string                        get(const std::string key);
+        header::value get(const std::string key);
 
-        std::map<std::string, std::string> headers();
+        header::map   headers();
 
-        size_t                             status() const;
+        size_t        status() const;
 
-        std::string                        status_text() const;
+        std::string   status_text() const;
 
-        std::string                        text() const;
+        std::string   text() const;
     private:
         // Member Fields
         
-        std::map<std::string, std::string> _headers;
-        size_t                             _status;
-        std::string                        _status_text;
-        std::string                        _text;
+        header::map   _headers;        
+        size_t        _status;
+        std::string   _status_text;
+        std::string   _text;
     };
 
     // Non-Member Functions
     
-    response request(
-        std::map<std::string, std::string>& headers,
-        const std::string                   url,
-        const std::string                   method = "GET",
-        const std::string                   body = ""
-    );
+    response request(header::map& headers, const std::string url, const std::string method = "GET", const std::string body = "");
 
     /**
      * Returns request timeout
      */
-    size_t& timeout();
+    size_t&  timeout();
 }
 
 #endif /* fetch_h */

--- a/fetch/src/main.cpp
+++ b/fetch/src/main.cpp
@@ -8,16 +8,13 @@
 #include "fetch.h"
 
 using namespace fetch;
-using namespace mysocket;
 using namespace std;
 
-map<string, string> headers = {{ "content-type", "application/json" }};
+header::map headers = {{ "content-type", header::value("application/json") }};
 
 int main(int argc, const char * argv[]) {
-    // auto server = new tcp_server(8082);
-
     string url = "http://localhost:8081/greeting";
-    // string url = "http://localhost:8082/greeting";
+    // string url = "http://localhost:8081/no-reply";
 
     string method = "POST";
     string body = "{ \"firstName\": \"Corey\" }";
@@ -27,7 +24,6 @@ int main(int argc, const char * argv[]) {
 
         cout << response.text() << endl;
     } catch (fetch::error& e) {
-        // server->close();
 
         if (e.text().length())
             throw fetch::error(e.status(), e.text(), e.text(), e.headers());

--- a/fetch/src/util/util.cpp
+++ b/fetch/src/util/util.cpp
@@ -153,7 +153,7 @@ bool is_int(const std::string value) {
     
     // leading positive (+) or negative (-) sign
     if (i != value.length() && (value[i] == '+' || value[i] == '-'))
-        ++i;
+        i++;
     
     if (i == value.length())
         return false;

--- a/test-server/src/api-doc.yaml
+++ b/test-server/src/api-doc.yaml
@@ -34,6 +34,34 @@ paths:
             application/json:
               schema:
                 type: string
+
+  "/no-reply":
+    get:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    post:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    put:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    patch:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    delete:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+          
   "/ping":
     get:
       operationId: ping

--- a/test-server/src/index.js
+++ b/test-server/src/index.js
@@ -47,6 +47,7 @@ const main = () => {
                 status: 400
             }, req, res);
         },
+        doNotReply: (c, req, res) => {},
         greeting: (c, req, res) => {
             Request.receive(req.url, req.body);
 

--- a/test-server/src/service/greeting.service.js
+++ b/test-server/src/service/greeting.service.js
@@ -35,7 +35,7 @@ class GreetingService {
         tomorrow.setSeconds(0);
 
         // Increment day at midnight
-        setTimeout(() => this.incrementDay(), tomorrow.getMilliseconds() - today.getMilliseconds());
+        setTimeout(() => this.incrementDay(), tomorrow.getTime() - today.getTime());
     }
 
     // Member Functions


### PR DESCRIPTION
Enhancement #11

- Create fetch::header::value type to serve both int and string values

Expected behavior:

fetch::header::value host = "127.0.0.1:8000”;
fetch::header::value content_length = 0;

std::string _host = host;
int _content_length = content_length;